### PR TITLE
#77: Add in pause after specific interval, "skip" silences 

### DIFF
--- a/Source/Engine/AudioEngine.swift
+++ b/Source/Engine/AudioEngine.swift
@@ -205,16 +205,16 @@ class AudioEngine: AudioEngineProtocol {
     }
 
     private func scaledPower(power: Float) -> Float {
-            guard power.isFinite else { return 0.0 }
-            let minDb: Float = -80.0
-            if power < minDb {
-                return 0.0
-            } else if power >= 1.0 {
-                return 1.0
-            } else {
-                return (abs(minDb) - abs(power)) / abs(minDb)
-            }
+        guard power.isFinite else { return 0.0 }
+        let minDb: Float = -80.0
+        if power < minDb {
+            return 0.0
+        } else if power >= 1.0 {
+            return 1.0
+        } else {
+            return (abs(minDb) - abs(power)) / abs(minDb)
         }
+    }
 
     private func connectVolumeTap() {
         let format = engine.mainMixerNode.outputFormat(forBus: 0)

--- a/Source/SAAudioQueue.swift
+++ b/Source/SAAudioQueue.swift
@@ -1,0 +1,8 @@
+//
+//  SAAudioQueue.swift
+//  SwiftAudioPlayer
+//
+//  Created by Joe Williams on 09/03/2021.
+//
+
+import Foundation

--- a/Source/SAPlayer.swift
+++ b/Source/SAPlayer.swift
@@ -44,6 +44,8 @@ public class SAPlayer {
     
     private var presenter: SAPlayerPresenter!
     private var player: AudioEngine?
+    private var timer: Timer?
+    var skipSilences: Bool = false
     
     /**
     Access the engine of the player. Engine is nil if player has not been initialized with audio.
@@ -194,6 +196,11 @@ public class SAPlayer {
         }
         
         audioModifiers.append(AVAudioUnitTimePitch(audioComponentDescription: componentDescription))
+    }
+
+    deinit {
+        timer?.invalidate()
+        timer = nil
     }
     
     /**
@@ -405,6 +412,10 @@ extension SAPlayer {
         player = nil
         presenter.handleClear()
     }
+
+    public func enableSkipSilences(_ bool: Bool) {
+        presenter.handleSkippingSilences(bool)
+    }
 }
 
 
@@ -457,6 +468,16 @@ extension SAPlayer: SAPlayerDelegate {
         var seekToNeedle = needle < 0 ? 0 : needle
         seekToNeedle = needle > Needle(duration ?? 0) ? Needle(duration ?? 0) : needle
         player?.seek(toNeedle: seekToNeedle)
+    }
+
+    func handleSkippingSilences(_ bool: Bool) {
+        skipSilences = bool
+    }
+
+    public func pause(after delay: Double) {
+        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false, block: { [weak self] _ in
+            self?.presenter.handleTogglePlayingAndPausing()
+        })
     }
 }
 

--- a/Source/SAPlayerDelegate.swift
+++ b/Source/SAPlayerDelegate.swift
@@ -36,4 +36,5 @@ protocol SAPlayerDelegate: AnyObject, LockScreenViewProtocol {
     func playEngine()
     func pauseEngine()
     func seekEngine(toNeedle needle: Needle) //TODO ensure that engine cleans up out of bounds
+    func handleSkippingSilences(_ bool: Bool)
 }

--- a/Source/SAPlayerPresenter.swift
+++ b/Source/SAPlayerPresenter.swift
@@ -182,6 +182,10 @@ extension SAPlayerPresenter {
     func handleScrubbingIntervalsChanged() {
         delegate?.updateLockscreenSkipIntervals()
     }
+    
+    func handleSkippingSilences(_ bool: Bool) {
+        delegate?.handleSkippingSilences(bool)
+    }
 }
 
 //MARK:- For lock screen

--- a/SwiftAudioPlayer.podspec
+++ b/SwiftAudioPlayer.podspec
@@ -25,7 +25,7 @@ SwiftAudioPlayer is a Swift based audio player that can handle streaming from a 
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'tanhakabir' => 'tanhakabir.ca@gmail.com', 'JonMercer' => 'mercer.jon@gmail.com' }
-  s.source           = { :git => 'https://github.com/jw1540/SwiftAudioPlayer.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/tanhakabir/SwiftAudioPlayer.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '10.0'

--- a/SwiftAudioPlayer.podspec
+++ b/SwiftAudioPlayer.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftAudioPlayer'
-  s.version          = '2.13.0'
+  s.version          = '2.13.1'
   s.summary          = 'SwiftAudioPlayer is a Swift based audio player that can handle streaming from a remote location and audio manipulation.'
 
 # This description is used to generate tags and improve search results.
@@ -25,7 +25,7 @@ SwiftAudioPlayer is a Swift based audio player that can handle streaming from a 
   # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'tanhakabir' => 'tanhakabir.ca@gmail.com', 'JonMercer' => 'mercer.jon@gmail.com' }
-  s.source           = { :git => 'https://github.com/tanhakabir/SwiftAudioPlayer.git', :tag => s.version.to_s }
+  s.source           = { :git => 'https://github.com/jw1540/SwiftAudioPlayer.git', :tag => s.version.to_s }
   # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '10.0'


### PR DESCRIPTION
PR adds a crude implementation on skipping silences. It basically checks when the average power for the currently playing buffer drops below an arbitrary value, and then increases the rate. Once the power returns above the value, the rate is reduced back to 1.0. 

Pausing after a time just runs a timer for that period and then calls pause. Perhaps it should also observe the playing status and remove itself if the audio file ends prior to the timer completing? 