### PR TITLE
Fix for https://github.com/tanhakabir/SwiftAudioPlayer/issues/76

### DIFF
--- a/Source/SAPlayerFeatures.swift
+++ b/Source/SAPlayerFeatures.swift
@@ -31,12 +31,12 @@ extension SAPlayer {
              
              - Important: The first audio modifier must be the default `AVAudioUnitTimePitch` that comes with the SAPlayer for this feature to work.
              */
-            public static func enable(fromRate rate: Float = SAPlayer.shared.rate ?? 1.0) -> Bool {
+            public static func enable() -> Bool {
                 guard let engine = SAPlayer.shared.engine else { return false }
                 
                 Log.info("enabling skip silences feature")
                 enabled = true
-                originalRate = rate
+                originalRate = SAPlayer.shared.rate ?? 1.0
                 let format = engine.mainMixerNode.outputFormat(forBus: 0)
                 
                 

--- a/Source/SAPlayerFeatures.swift
+++ b/Source/SAPlayerFeatures.swift
@@ -24,18 +24,19 @@ extension SAPlayer {
         public struct SkipSilences {
             
             static var enabled: Bool = false
+            static var originalRate: Float = 1.0
             
             /**
              Enable feature to skip silences in spoken word audio. The player will speed up the rate of audio playback when silence is detected. This can be called at any point of audio playback.
              
              - Important: The first audio modifier must be the default `AVAudioUnitTimePitch` that comes with the SAPlayer for this feature to work.
              */
-            public static func enable() -> Bool {
+            public static func enable(fromRate rate: Float = SAPlayer.shared.rate ?? 1.0) -> Bool {
                 guard let engine = SAPlayer.shared.engine else { return false }
                 
                 Log.info("enabling skip silences feature")
                 enabled = true
-                let originalRate = SAPlayer.shared.rate ?? 1.0
+                originalRate = rate
                 let format = engine.mainMixerNode.outputFormat(forBus: 0)
                 
                 
@@ -74,10 +75,10 @@ extension SAPlayer {
              - Important: The first audio modifier must be the default `AVAudioUnitTimePitch` that comes with the SAPlayer for this feature to work.
              */
             public static func disable() -> Bool {
-                // TODO fix disabling on speed up portion and being stuck at faster speed https://github.com/tanhakabir/SwiftAudioPlayer/issues/76
                 guard let engine = SAPlayer.shared.engine else { return false }
                 Log.info("disabling skip silences feature")
                 engine.mainMixerNode.removeTap(onBus: 0)
+                SAPlayer.shared.rate = originalRate
                 enabled = false
                 return true
             }


### PR DESCRIPTION
This fix the issue with playback rate not going back to original rate when disabling skip silences feature. It also allows to pass original rate as an argument when enabling feature.