### PR TITLE
Fix for https://github.com/tanhakabir/SwiftAudioPlayer/issues/95

### DIFF
--- a/Source/SAPlayer.swift
+++ b/Source/SAPlayer.swift
@@ -281,9 +281,8 @@ public class SAPlayer {
      */
     public static func prettifyTimestamp(_ timestamp: Double) -> String {
         let hours = Int(timestamp / 60 / 60)
-        let minutes = Int((timestamp - Double(hours * 60)) / 60)
-        
-        let secondsLeft = Int(timestamp) - (minutes * 60)
+        let minutes = Int((timestamp - Double(hours * 60 * 60)) / 60)
+        let secondsLeft = Int(timestamp - Double(hours * 60 * 60) - Double(minutes * 60))
         
         return "\(hours):\(String(format: "%02d", minutes)):\(String(format: "%02d", secondsLeft))"
     }


### PR DESCRIPTION
Here's a fix for an issue that duration is not properly converted to string for some longer audio files. (File from the screenshot: https://traffic.libsyn.com/secure/daringfireball/thetalkshow-312-craig-mod.mp3)