### PR TITLE
Fix for audio session setup on iOS 11 and up

### DIFF
--- a/Source/SAPlayer.swift
+++ b/Source/SAPlayer.swift
@@ -523,12 +523,10 @@ extension SAPlayer: SAPlayerDelegate {
     private func becomeDeviceAudioPlayer() {
         do {
             if #available(iOS 11.0, *) {
-//                try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio, policy: .longForm, options: [])
+                try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio, policy: .longFormAudio, options: [])
             } else {
-                // Fallback on earlier versions
+                try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: AVAudioSession.Mode(rawValue: convertFromAVAudioSessionMode(AVAudioSession.Mode.default)), options: .allowAirPlay)
             }
-            try AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: AVAudioSession.Mode(rawValue: convertFromAVAudioSessionMode(AVAudioSession.Mode.default)), options: .allowAirPlay)
-
             try AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             Log.monitor("Problem setting up AVAudioSession to play in:: \(error.localizedDescription)")


### PR DESCRIPTION
I was getting cosistent error from `AVAudioSession.sharedInstance().setCategory` because of option `.allowAirPlay`. This fix the problem for me: session is properly activated and audio route picking works correctly.