### PR TITLE
feat: pause player on interruption, resume when necessary

### DIFF
--- a/Source/SAPlayer.swift
+++ b/Source/SAPlayer.swift
@@ -244,6 +244,7 @@ public class SAPlayer {
         }
         
         audioModifiers.append(AVAudioUnitTimePitch(audioComponentDescription: componentDescription))
+	NotificationCenter.default.addObserver(self, selector: #selector(handleInterruption), name: AVAudioSession.interruptionNotification, object: nil)
     }
     
     /**
@@ -283,6 +284,36 @@ public class SAPlayer {
     func addUrlToMapping(url: URL) {
         presenter.addUrlToKeyMap(url)
     }
+    
+    @objc func handleInterruption(notification: Notification) {
+        guard let userInfo = notification.userInfo,
+            let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+            let type = AVAudioSession.InterruptionType(rawValue: typeValue) else {
+                return
+        }
+
+        // Switch over the interruption type.
+        switch type {
+
+        case .began:
+            // An interruption began. Update the UI as necessary.
+            player?.pause()
+
+        case .ended:
+           // An interruption ended. Resume playback, if appropriate.
+
+            guard let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt else { return }
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+            if options.contains(.shouldResume) {
+                // An interruption ended. Resume playback.
+                player?.play()
+            } else {
+                // An interruption ended. Don't resume playback.
+            }
+
+        default: ()
+        }
+    }	
 }
 
 public enum SAPlayerBitrate {


### PR DESCRIPTION
This fixes: https://github.com/tanhakabir/SwiftAudioPlayer/issues/112 (song skipping after receiving a phone call / Siri interruption)

I'm not exactly sure if this is the best place to add the observer, but it works.