### PR TITLE
Fix seek fail issue when data is not loaded for AudioStreamEngine.

### DIFF
--- a/Source/Engine/AudioDiskEngine.swift
+++ b/Source/Engine/AudioDiskEngine.swift
@@ -116,10 +116,11 @@ class AudioDiskEngine: AudioEngine {
         }
         
         let playing = playerNode.isPlaying
+        let seekToNeedle = needle > Needle(duration) ? Needle(duration) : needle
         
-        self.needle = needle // to tick while paused
+        self.needle = seekToNeedle // to tick while paused
         
-        seekFrame = AVAudioFramePosition(Float(needle) * audioSampleRate)
+        seekFrame = AVAudioFramePosition(Float(seekToNeedle) * audioSampleRate)
         seekFrame = max(seekFrame, 0)
         seekFrame = min(seekFrame, audioLengthSamples)
         currentPosition = seekFrame

--- a/Source/Engine/AudioStreamEngine.swift
+++ b/Source/Engine/AudioStreamEngine.swift
@@ -266,6 +266,15 @@ class AudioStreamEngine: AudioEngine {
     //MARK:- Overriden From Parent
     override func seek(toNeedle needle: Needle) {
         Log.info("didSeek to needle: \(needle)")
+
+        // if not playable (data not loaded etc), duration could be zero.
+        guard isPlayable else {
+            if predictedStreamDuration == 0 {
+                seekNeedleCommandBeforeEngineWasReady = needle
+            }
+            return
+        }
+
         guard needle < (ceil(predictedStreamDuration)) else {
             if !isPlayable {
                 seekNeedleCommandBeforeEngineWasReady = needle

--- a/Source/SAPlayer.swift
+++ b/Source/SAPlayer.swift
@@ -572,8 +572,7 @@ extension SAPlayer: SAPlayerDelegate {
     }
     
     func seekEngine(toNeedle needle: Needle) {
-        var seekToNeedle = needle < 0 ? 0 : needle
-        seekToNeedle = needle > Needle(duration ?? 0) ? Needle(duration ?? 0) : needle
+        let seekToNeedle = needle < 0 ? 0 : needle
         player?.seek(toNeedle: seekToNeedle)
     }
 }


### PR DESCRIPTION
Call 
```swift
player.startRemoteAudio(withRemoteUrl: url)
``` 
Then call 
```swift
player.seekTo(seconds: seconds)
```
seek will be fail.
Because data is not loaded.