### PR TITLE
Bug fix for resetting cache

### DIFF
--- a/Source/SAPlayerPresenter.swift
+++ b/Source/SAPlayerPresenter.swift
@@ -73,6 +73,7 @@ class SAPlayerPresenter {
         mediaInfo = nil
         delegate?.clearLockScreenInfo()
         
+        AudioClockDirector.shared.clear()
         AudioClockDirector.shared.detachFromChangesInDuration(withID: durationRef)
         AudioClockDirector.shared.detachFromChangesInNeedle(withID: needleRef)
         AudioClockDirector.shared.detachFromChangesInPlayingStatus(withID: playingStatusRef)


### PR DESCRIPTION
After a user has called clear on AudioClockDirector, the cache will be reset

## Problem:
In the case of playing multiple audio files and choosing another audio in the middle of the first file, the `SAPlayer.Updates.ElapsedTime.subscribe` will be called half played files elapsed by the number of items in the cache. By calling `AudioClockDirector.shared.clear()` inside the `handleClear()` method of the `SAPlayerPresenter` class. If the `SAPlayer.shared.clear()` method is called, the cache will be cleared.

