### PR TITLE
Lockscreen Media Player as public for other players.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can also directly access and modify the queue from `SAPlayer.shared.audioQue
 
 The engine can handle audio manipulations like speed, pitch, effects, etc. To do this, nodes for effects must be finalized before initialize is called. Look at [audio manipulation documentation](#realtime-audio-manipulation) for more information.
 
-### Lockscreen Media Player
+### LockScreen Media Player
  
 Update and set what displays on the lockscreen's media player when the player is active. 
 


### PR DESCRIPTION
I use `AVAudioPlayer` for playing `kAudioFileStreamError_NotOptimized` audio files.
So I can setup Lockscreen Media Player like this:

```swift
extension AVAudioPlayer : LockScreenViewPresenter {

    public func getIsPlaying() -> Bool { isPlaying }

    public func handlePlay() { play() }

    public func handlePause() { pause() }

    public func handleSkipBackward() {}

    public func handleSkipForward() {}

    public func handleSeek(toNeedle needle: Double) { currentTime = needle }
}

private var skipForwardSecondsKey: UInt8 = 0
private var skipBackwardSecondsKey: UInt8 = 0

extension AVAudioPlayer : LockScreenViewProtocol {

    public var skipForwardSeconds: Double {
        get {
            guard let value = objc_getAssociatedObject(self, &skipForwardSecondsKey) as? NSNumber else {
                return 0
            }

            return value.doubleValue
        }

        set(newValue) {
            objc_setAssociatedObject(self, &skipForwardSecondsKey, NSNumber(value: newValue), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
        }
    }

    public var skipBackwardSeconds: Double {
        get {
            guard let value = objc_getAssociatedObject(self, &skipBackwardSecondsKey) as? NSNumber else {
                return 0
            }

            return value.doubleValue
        }
        set(newValue) {
            objc_setAssociatedObject(self, &skipBackwardSecondsKey, NSNumber(value: newValue), .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
        }
    }

}
```